### PR TITLE
fix: bound recovery retry loop and handle unrecoverable WAL segments

### DIFF
--- a/sparkplug-historian/sparkplug-sql/historian.go
+++ b/sparkplug-historian/sparkplug-sql/historian.go
@@ -296,19 +296,19 @@ DO
 }
 
 func invalidateAliases(node_id string) {
-	ctx, cancel := dbCtx()
-	defer cancel()
 	log.Info().
 		Str("node_id", node_id).
-		Msg("NDEATH: invaldiating aliases")
+		Msg("NDEATH: invalidating aliases")
 	sqlStatement := `
 UPDATE metadata
 SET metric_alias = NULL
 WHERE group_name = $1 AND node_name = $2
 `
 	for {
+		ctx, cancel := dbCtx()
 		_, err := pool.Exec(ctx, sqlStatement,
 			SPARKPLUG_GROUP_ID, node_id)
+		cancel()
 		if err != nil {
 			log.Error().Err(err).Msg("Error invalidating aliases; cannot continue since future inserts may be incorrect")
 		} else {
@@ -805,6 +805,11 @@ func makeRetryCmd(node_id string) string {
 // data from the node).
 func trackVersions(group_id string, node_id string) {
 	var TRACK_VERSION_EPOCH = 300 * time.Second
+	// After this many consecutive DESYNCED→RECOVERING cycles with no hdata
+	// received, give up and mark the node GOOD. Prevents an unbounded
+	// retry-request loop that wipes alias maps and generates .recovery files
+	// when a node cannot fulfill the requested sequence number.
+	maxRecoveryAttempts := getEnvInt("MAX_RECOVERY_ATTEMPTS", 5)
 
 	nodes_mu.Lock()
 	state := nodes[node_id]
@@ -817,10 +822,12 @@ func trackVersions(group_id string, node_id string) {
 		Uint64("lgsn", state.lgsn).
 		Msg("Loaded LGSN from database")
 
+	recoveryAttempts := 0
 	for {
 		log.Info().
 			Str("node_id", node_id).
 			Int("state", state.state).
+			Int("recovery_attempts", recoveryAttempts).
 			Bool("hdata", state.epoch_hdata_received).
 			Msg("Checking recovery state")
 
@@ -831,6 +838,16 @@ func trackVersions(group_id string, node_id string) {
 
 		switch state.state {
 		case STATE_DESYNCED:
+			if maxRecoveryAttempts > 0 && recoveryAttempts >= maxRecoveryAttempts {
+				log.Warn().
+					Str("node_id", node_id).
+					Int("attempts", recoveryAttempts).
+					Msg("Max recovery attempts reached; giving up on historical backfill")
+				state.state = STATE_GOOD
+				state.recovery_id = ""
+				recoveryAttempts = 0
+				break
+			}
 			log.Info().
 				Uint64("seq", state.lgsn).
 				Str("node_id", node_id).
@@ -839,12 +856,16 @@ func trackVersions(group_id string, node_id string) {
 				1, false, makeRetryCmd(node_id))
 			if token.Wait() && token.Error() == nil {
 				state.state = STATE_RECOVERING
+				recoveryAttempts++
 			}
 		case STATE_RECOVERING:
 			if !state.epoch_hdata_received {
 				state.state = STATE_DESYNCED
+			} else {
+				recoveryAttempts = 0
 			}
 		case STATE_GOOD:
+			recoveryAttempts = 0
 		}
 		state.epoch_hdata_received = false
 		time.Sleep(TRACK_VERSION_EPOCH)

--- a/sparkplug-historian/sparkplug-sql/historian.go
+++ b/sparkplug-historian/sparkplug-sql/historian.go
@@ -474,11 +474,22 @@ func insertData(topic []string, msg *sparkplug.Payload) {
 		Uint64("seq", *msg.Seq).
 		Msg("DDATA: Inserting Data")
 
+	var unmappable []*sparkplug.Payload_Metric
+
+	// INSERT...SELECT inserts zero rows (instead of violating the not-null
+	// constraint) when the metric_alias lookup misses, so one unmappable
+	// metric can no longer roll back an entire batch of good data.
 	const insertStatement = `
-INSERT INTO metrics (metric_id, time, value) VALUES (
- (SELECT id FROM metadata WHERE group_name = $1 AND
-   node_name = $2 AND device_name = $3 AND metric_alias = $4), to_timestamp($5), $6)
+INSERT INTO metrics (metric_id, time, value)
+SELECT id, to_timestamp($5), $6
+FROM metadata
+WHERE group_name = $1 AND node_name = $2 AND device_name = $3 AND metric_alias = $4
 ON CONFLICT (metric_id, time) DO NOTHING`
+
+	// queued holds the metrics we actually queue, in queue order, so we can
+	// map per-statement Exec results back to metrics.
+	queued := make([]*sparkplug.Payload_Metric, 0, len(msg.Metrics))
+
 	err := pool.BeginFunc(ctx, func(tx pgx.Tx) error {
 		b := &pgx.Batch{}
 		inserts := 0
@@ -515,15 +526,32 @@ DO UPDATE SET lgsn = $3`, group_id, node_id, *msg.Seq)
 					makeScalar(metric),
 				)
 				inserts++
+				queued = append(queued, metric)
 			}
 		}
 
 		batchResults := tx.SendBatch(ctx, b)
 		for i := 0; i < inserts; i++ {
-			_, err := batchResults.Exec()
+			tag, err := batchResults.Exec()
 			if err != nil {
 				batchResults.Close()
 				return err
+			}
+			// First queued statement (when GOOD) is the lgsn upsert;
+			// skip it when mapping results back to metrics.
+			if state.state == STATE_GOOD && i == 0 {
+				continue
+			}
+			metricIdx := i
+			if state.state == STATE_GOOD {
+				metricIdx--
+			}
+			// RowsAffected()==0 means the alias lookup missed (no
+			// metadata row) or the row already existed (conflict).
+			// Spool it so a later replay can recover it once the
+			// device re-births; conflicts replay harmlessly.
+			if tag.RowsAffected() == 0 && metricIdx < len(queued) {
+				unmappable = append(unmappable, queued[metricIdx])
 			}
 		}
 
@@ -541,6 +569,15 @@ DO UPDATE SET lgsn = $3`, group_id, node_id, *msg.Seq)
 	} else {
 		if state.state == STATE_GOOD && msg.Seq != nil {
 			state.lgsn = *msg.Seq
+		}
+		if len(unmappable) > 0 {
+			log.Info().
+				Str("node_id", node_id).
+				Str("device_id", device_id).
+				Int("unmappable", len(unmappable)).
+				Int("inserted", len(queued)-len(unmappable)).
+				Msg("DDATA: partial insert, spooling unmappable metrics to recovery log")
+			logAllMetrics(node_id, device_id, unmappable, false)
 		}
 		logAllMetrics(node_id, device_id, msg.Metrics, true)
 	}
@@ -810,6 +847,12 @@ func trackVersions(group_id string, node_id string) {
 	// retry-request loop that wipes alias maps and generates .recovery files
 	// when a node cannot fulfill the requested sequence number.
 	maxRecoveryAttempts := getEnvInt("MAX_RECOVERY_ATTEMPTS", 5)
+	// After this many consecutive RECOVERING checks with no hdata received,
+	// give up waiting for backfill and mark the node GOOD (accepting the
+	// gap). This is the escape hatch for a node live-locked in RECOVERING:
+	// transient insert failures can keep re-poking state=RECOVERING before
+	// the DESYNCED branch (and its give-up path) ever runs. 6 checks ≈ 30m.
+	recoveringGiveupChecks := getEnvInt("RECOVERING_GIVEUP_CHECKS", 6)
 
 	nodes_mu.Lock()
 	state := nodes[node_id]
@@ -823,6 +866,7 @@ func trackVersions(group_id string, node_id string) {
 		Msg("Loaded LGSN from database")
 
 	recoveryAttempts := 0
+	recoveringNoHdata := 0
 	for {
 		log.Info().
 			Str("node_id", node_id).
@@ -860,7 +904,21 @@ func trackVersions(group_id string, node_id string) {
 			}
 		case STATE_RECOVERING:
 			if !state.epoch_hdata_received {
-				state.state = STATE_DESYNCED
+				recoveringNoHdata++
+				if recoveringGiveupChecks > 0 && recoveringNoHdata >= recoveringGiveupChecks {
+					log.Warn().
+						Str("node_id", node_id).
+						Int("checks", recoveringNoHdata).
+						Msg("No historical data after repeated recovery checks; marking node GOOD (accepting gap)")
+					state.state = STATE_GOOD
+					state.recovery_id = ""
+					recoveryAttempts = 0
+					recoveringNoHdata = 0
+				} else {
+					state.state = STATE_DESYNCED
+				}
+			} else {
+				recoveringNoHdata = 0
 			}
 		case STATE_GOOD:
 			// Only reset on full recovery (NDATA UUID match → STATE_GOOD).
@@ -868,6 +926,7 @@ func trackVersions(group_id string, node_id string) {
 			// that keeps bouncing DESYNCED→RECOVERING with only heartbeat
 			// traffic would otherwise never exhaust the limit.
 			recoveryAttempts = 0
+			recoveringNoHdata = 0
 		}
 		state.epoch_hdata_received = false
 		time.Sleep(TRACK_VERSION_EPOCH)

--- a/sparkplug-historian/sparkplug-sql/historian.go
+++ b/sparkplug-historian/sparkplug-sql/historian.go
@@ -861,10 +861,12 @@ func trackVersions(group_id string, node_id string) {
 		case STATE_RECOVERING:
 			if !state.epoch_hdata_received {
 				state.state = STATE_DESYNCED
-			} else {
-				recoveryAttempts = 0
 			}
 		case STATE_GOOD:
+			// Only reset on full recovery (NDATA UUID match → STATE_GOOD).
+			// Partial hdata in RECOVERING does not reset the counter — a node
+			// that keeps bouncing DESYNCED→RECOVERING with only heartbeat
+			// traffic would otherwise never exhaust the limit.
 			recoveryAttempts = 0
 		}
 		state.epoch_hdata_received = false

--- a/sparkplug-historian/sparkplug-sql/historian_test.go
+++ b/sparkplug-historian/sparkplug-sql/historian_test.go
@@ -29,8 +29,10 @@ package main
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -95,6 +97,58 @@ func applyDDL(ctx context.Context) error {
 func sp(s string) *string   { return &s }
 func u64(n uint64) *uint64  { return &n }
 func boolp(b bool) *bool    { return &b }
+
+// ---- WAL test helpers ----
+
+// findSegment returns the single WAL segment file for a node/device in the
+// test DATA_DIR.
+func findSegment(t *testing.T, nodeID, deviceID string) string {
+	t.Helper()
+	dir := filepath.Join(DATA_DIR, SPARKPLUG_GROUP_ID, nodeID, deviceID)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read WAL dir: %v", err)
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			return filepath.Join(dir, e.Name())
+		}
+	}
+	t.Fatalf("no WAL segment found in %s", dir)
+	return ""
+}
+
+// readSegment parses a WAL segment into records.
+func readSegment(t *testing.T, path string) []record {
+	t.Helper()
+	f, err := os.Open(filepath.Clean(path))
+	if err != nil {
+		t.Fatalf("open segment: %v", err)
+	}
+	defer f.Close()
+	info, err := f.Stat()
+	if err != nil {
+		t.Fatalf("stat segment: %v", err)
+	}
+	var tmp record
+	data := make([]record, info.Size()/int64(binary.Size(tmp)))
+	if err := binary.Read(f, binary.LittleEndian, &data); err != nil {
+		t.Fatalf("read segment: %v", err)
+	}
+	return data
+}
+
+func TestBackoffFor(t *testing.T) {
+	if d := backoffFor(1); d != 30*time.Second {
+		t.Errorf("backoffFor(1) = %v, want 30s", d)
+	}
+	if d := backoffFor(2); d != time.Minute {
+		t.Errorf("backoffFor(2) = %v, want 1m", d)
+	}
+	if d := backoffFor(20); d != time.Hour {
+		t.Errorf("backoffFor(20) = %v, want capped 1h", d)
+	}
+}
 
 // ---- tests ----
 
@@ -259,6 +313,127 @@ func TestHistorian(t *testing.T) {
 	})
 
 	// ------------------------------------------------------------------
+	// DDATA with one unmappable alias — the rest of the batch must
+	// still land (no whole-batch rollback), state must NOT be poked
+	// to RECOVERING, and the unmappable metric must be spooled to the
+	// WAL as an alias-encoded record.
+	// ------------------------------------------------------------------
+	t.Run("DDATA partial insert on unmappable metric", func(t *testing.T) {
+		// +2s: insertData stores to_timestamp(ms/1000) — same-second
+		// timestamps would ON CONFLICT with the earlier DDATA subtest.
+		ts := uint64(time.Now().UnixMilli()) + 2000
+		seq := uint64(3)
+		payload := &sparkplug.Payload{
+			Timestamp: u64(ts),
+			Seq:       &seq,
+			Metrics: []*sparkplug.Payload_Metric{
+				{
+					Alias:     u64(1),
+					Timestamp: u64(ts),
+					Value:     &sparkplug.Payload_Metric_DoubleValue{DoubleValue: 24.0},
+				},
+				{
+					Alias:     u64(99), // not registered by any DBIRTH
+					Timestamp: u64(ts),
+					Value:     &sparkplug.Payload_Metric_DoubleValue{DoubleValue: 101.3},
+				},
+			},
+		}
+
+		insertData(topic("DDATA"), payload)
+
+		ctx := context.Background()
+		var count int
+		if err := pool.QueryRow(ctx,
+			`SELECT COUNT(*) FROM metrics m
+			 JOIN metadata md ON m.metric_id = md.id
+			 WHERE md.node_name = $1 AND md.device_name = $2 AND md.metric_name = 'temperature'`,
+			nodeID, deviceID,
+		).Scan(&count); err != nil {
+			t.Fatalf("query metrics: %v", err)
+		}
+		// 1 row from this DDATA + 1 from the earlier DDATA subtest.
+		if count != 2 {
+			t.Errorf("expected 2 temperature rows (good metric must land), got %d", count)
+		}
+
+		// State must remain GOOD — an unmappable metric is not a
+		// recovery event.
+		nodes_mu.Lock()
+		st := nodes[nodeID].state
+		nodes_mu.Unlock()
+		if st != STATE_GOOD {
+			t.Errorf("expected state STATE_GOOD after partial insert, got %d", st)
+		}
+
+		// The unmappable metric must be spooled alias-encoded in the WAL.
+		seg := findSegment(t, nodeID, deviceID)
+		recs := readSegment(t, seg)
+		if len(recs) == 0 {
+			t.Fatal("expected WAL segment with spooled records, got none")
+		}
+		found := false
+		for _, r := range recs {
+			if recordName(r) == "!alias:99" {
+				found = true
+				if r.Val != 101.3 {
+					t.Errorf("alias record value: expected 101.3, got %v", r.Val)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("no !alias:99 record in WAL segment (%d records)", len(recs))
+		}
+
+		// Replay before the alias is registered must report unresolved
+		// (transient) so the segment is kept.
+		if err := insertRecoveryData(nodeID, deviceID, recs); err == nil {
+			t.Error("expected errUnresolved replaying before alias registration, got nil")
+		}
+	})
+
+	// ------------------------------------------------------------------
+	// WAL alias-encoded replay — once the device re-births and the
+	// alias is registered, the spooled record must land.
+	// ------------------------------------------------------------------
+	t.Run("WAL alias replay after re-birth", func(t *testing.T) {
+		now := uint64(time.Now().UnixMilli())
+		payload := &sparkplug.Payload{
+			Timestamp: u64(now),
+			Seq:       u64(4),
+			Metrics: []*sparkplug.Payload_Metric{
+				{
+					Name:      sp("pressure"),
+					Alias:     u64(99),
+					Timestamp: u64(now),
+					Value:     &sparkplug.Payload_Metric_DoubleValue{DoubleValue: 0},
+				},
+			},
+		}
+		updateAliases(topic("DBIRTH"), payload)
+
+		seg := findSegment(t, nodeID, deviceID)
+		recs := readSegment(t, seg)
+		if err := insertRecoveryData(nodeID, deviceID, recs); err != nil {
+			t.Fatalf("replay after re-birth: %v", err)
+		}
+
+		ctx := context.Background()
+		var val float64
+		if err := pool.QueryRow(ctx,
+			`SELECT m.value FROM metrics m
+			 JOIN metadata md ON m.metric_id = md.id
+			 WHERE md.node_name = $1 AND md.device_name = $2 AND md.metric_name = 'pressure'`,
+			nodeID, deviceID,
+		).Scan(&val); err != nil {
+			t.Fatalf("query replayed metric: %v", err)
+		}
+		if val != 101.3 {
+			t.Errorf("expected replayed value 101.3, got %v", val)
+		}
+	})
+
+	// ------------------------------------------------------------------
 	// NDEATH — aliases are invalidated in the database
 	// ------------------------------------------------------------------
 	t.Run("NDEATH invalidates aliases", func(t *testing.T) {
@@ -273,8 +448,8 @@ func TestHistorian(t *testing.T) {
 		).Scan(&nullCount); err != nil {
 			t.Fatalf("query metadata: %v", err)
 		}
-		if nullCount != 2 {
-			t.Errorf("expected 2 rows with null alias after NDEATH, got %d", nullCount)
+		if nullCount != 3 {
+			t.Errorf("expected 3 rows with null alias after NDEATH, got %d", nullCount)
 		}
 	})
 }

--- a/sparkplug-historian/sparkplug-sql/wal.go
+++ b/sparkplug-historian/sparkplug-sql/wal.go
@@ -181,7 +181,17 @@ func recoverFile(path string, info os.FileInfo, err error) error {
 			Str("path", path).
 			Msg("Recovery failed")
 
-		if strings.Contains(err.Error(), "not permitted on chunk") {
+		errStr := err.Error()
+		// Mark files that will never succeed as .tooold so the recovery
+		// worker stops retrying them. "not permitted on chunk" means the
+		// data is outside TimescaleDB's retention window. "null value in
+		// column" / "violates not-null constraint" means the metric_id
+		// subquery returned NULL (metadata row missing or name truncated
+		// in the 36-byte WAL record) — retrying will never fix that.
+		if strings.Contains(errStr, "not permitted on chunk") ||
+			strings.Contains(errStr, "null value in column") ||
+			strings.Contains(errStr, "violates not-null constraint") {
+			log.Warn().Str("path", path).Msg("Marking unrecoverable segment as tooold")
 			os.Rename(path, path+".tooold")
 		}
 	}

--- a/sparkplug-historian/sparkplug-sql/wal.go
+++ b/sparkplug-historian/sparkplug-sql/wal.go
@@ -29,10 +29,12 @@ package main
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -49,6 +51,42 @@ type record struct {
 	Name [36]byte
 	Ts   uint64
 	Val  float64
+}
+
+// aliasRecordPrefix marks a WAL record whose metric name could not be
+// resolved when it was spooled (alias map wiped / device not yet birthed).
+// The number after the prefix is the Sparkplug metric alias.
+const aliasRecordPrefix = "!alias:"
+
+// errUnresolved is returned by insertRecoveryData when some records could
+// not be matched to metadata rows yet. It is transient: the segment is
+// kept and retried (with backoff) so data lands once the device re-births.
+var errUnresolved = errors.New("some records unresolved against metadata")
+
+// recordName decodes a WAL record name, stripping trailing NUL padding.
+func recordName(r record) string {
+	return strings.TrimRight(string(r.Name[:]), "\x00")
+}
+
+// recoveryBackoff tracks per-segment retry state for transient replay
+// failures (DB timeouts, unresolved metadata). Files are skipped until
+// their backoff expires instead of being retried every walk.
+type retryState struct {
+	failures  int
+	nextRetry time.Time
+}
+
+var recoveryBackoff = map[string]*retryState{}
+
+func backoffFor(failures int) time.Duration {
+	d := 30 * time.Second
+	for i := 1; i < failures; i++ {
+		d *= 2
+		if d >= time.Hour {
+			return time.Hour
+		}
+	}
+	return d
 }
 
 func logAllMetrics(node_id string, device_id string,
@@ -82,24 +120,31 @@ func logAllMetrics(node_id string, device_id string,
 			continue
 		}
 		if name == "" {
-			log.Debug().
-				Str("name", name).
-				Msg("Can't log historical metric due to invalid name")
-			continue
+			// Name unresolvable (alias map wiped / device not yet
+			// birthed). Spool an alias-encoded record instead of
+			// dropping the data point: replay resolves the alias via
+			// metadata.metric_alias once the device re-births.
+			if m.Alias == nil {
+				log.Debug().Msg("Can't log historical metric: no name and no alias")
+				continue
+			}
+			name = fmt.Sprintf("%s%d", aliasRecordPrefix, *m.Alias)
 		}
 
 		if only_historical && (m.IsHistorical == nil || !*m.IsHistorical) {
 			continue
 		}
 
-		var data = struct {
-			name [36]byte
-			n1   uint64
-			n2   float64
-		}{}
-		copy(data.name[:], name[:36])
-		data.n1 = *m.Timestamp
-		data.n2 = makeScalar(m)
+		if m.Timestamp == nil {
+			continue
+		}
+
+		// copy truncates at 36 bytes naturally; never slice the
+		// string (name[:36] panics on names shorter than 36 bytes).
+		var data record
+		copy(data.Name[:], name)
+		data.Ts = *m.Timestamp
+		data.Val = makeScalar(m)
 
 		err = binary.Write(f, binary.LittleEndian, data)
 		if err != nil {
@@ -127,6 +172,12 @@ func recoverFile(path string, info os.FileInfo, err error) error {
 	fmt.Sscanf(chunk, "%d-%02d-%02dT%02d:00", &year, &month, &day, &hour)
 	now := time.Now()
 	if strings.HasSuffix(path, ".tooold") {
+		return nil
+	}
+	// Transient-failure backoff: skip segments that aren't due for
+	// retry yet (DB timeouts, unresolved metadata) instead of
+	// hammering them on every 5-second walk.
+	if rs, ok := recoveryBackoff[path]; ok && now.Before(rs.nextRetry) {
 		return nil
 	}
 	if false && !strings.HasSuffix(path, ".recovery") && year == now.Year() &&
@@ -175,6 +226,7 @@ func recoverFile(path string, info os.FileInfo, err error) error {
 
 	err = insertRecoveryData(node_id, device_id, data)
 	if err == nil {
+		delete(recoveryBackoff, path)
 		os.Remove(path)
 	} else {
 		log.Error().Err(err).
@@ -182,17 +234,28 @@ func recoverFile(path string, info os.FileInfo, err error) error {
 			Msg("Recovery failed")
 
 		errStr := err.Error()
-		// Mark files that will never succeed as .tooold so the recovery
-		// worker stops retrying them. "not permitted on chunk" means the
-		// data is outside TimescaleDB's retention window. "null value in
-		// column" / "violates not-null constraint" means the metric_id
-		// subquery returned NULL (metadata row missing or name truncated
-		// in the 36-byte WAL record) — retrying will never fix that.
-		if strings.Contains(errStr, "not permitted on chunk") ||
-			strings.Contains(errStr, "null value in column") ||
-			strings.Contains(errStr, "violates not-null constraint") {
+		// Only "not permitted on chunk" (data outside TimescaleDB's
+		// retention window) is unambiguously permanent — mark .tooold
+		// so the worker stops retrying. Lookup misses are transient
+		// (metadata appears when the device re-births) and DB errors
+		// may clear, so everything else retries with capped backoff.
+		if strings.Contains(errStr, "not permitted on chunk") {
 			log.Warn().Str("path", path).Msg("Marking unrecoverable segment as tooold")
+			delete(recoveryBackoff, path)
 			os.Rename(path, path+".tooold")
+		} else {
+			rs := recoveryBackoff[path]
+			if rs == nil {
+				rs = &retryState{}
+				recoveryBackoff[path] = rs
+			}
+			rs.failures++
+			rs.nextRetry = time.Now().Add(backoffFor(rs.failures))
+			log.Warn().
+				Str("path", path).
+				Int("failures", rs.failures).
+				Time("next_retry", rs.nextRetry).
+				Msg("Recovery retry scheduled with backoff")
 		}
 	}
 
@@ -205,31 +268,88 @@ func insertRecoveryData(node_id string, device_id string, data []record) error {
 		Str("device_id", device_id).
 		Msg("Inserting values")
 
-	const insertStatement = `
-INSERT INTO metrics (metric_id, time, value) VALUES (
- (SELECT id FROM metadata WHERE group_name = $1 AND
-   node_name = $2 AND device_name = $3 AND metric_name = $4), to_timestamp($5), $6)
+	// Both lookups use INSERT...SELECT so a lookup miss inserts zero
+	// rows instead of aborting the whole batch on the not-null
+	// constraint. Misses are counted and reported as errUnresolved
+	// (transient) so the segment is retried later with backoff.
+	const insertByName = `
+INSERT INTO metrics (metric_id, time, value)
+SELECT id, to_timestamp($5), $6
+FROM metadata
+WHERE group_name = $1 AND node_name = $2 AND device_name = $3 AND metric_name = $4
 ON CONFLICT (metric_id, time) DO NOTHING`
+	const insertByAlias = `
+INSERT INTO metrics (metric_id, time, value)
+SELECT id, to_timestamp($5), $6
+FROM metadata
+WHERE group_name = $1 AND node_name = $2 AND device_name = $3 AND metric_alias = $4
+ON CONFLICT (metric_id, time) DO NOTHING`
+	// Replay in RECOVERY_STRIDE-sized chunks: segments can hold millions
+	// of records (240MB+ observed in production), and a single
+	// transaction would never fit inside dbCtx's 60s deadline.
+	misses := 0
+	for start := 0; start < len(data); start += RECOVERY_STRIDE {
+		end := start + RECOVERY_STRIDE
+		if end > len(data) {
+			end = len(data)
+		}
+		chunkMisses, err := insertRecoveryChunk(node_id, device_id, data[start:end], insertByName, insertByAlias)
+		if err != nil {
+			return err
+		}
+		misses += chunkMisses
+	}
+	log.Info().
+		Str("node_id", node_id).
+		Str("device_id", device_id).
+		Int("count", len(data)).
+		Int("unresolved", misses).
+		Msg("Recovery complete")
+	if misses > 0 {
+		return errUnresolved
+	}
+	return nil
+}
+
+func insertRecoveryChunk(node_id, device_id string, data []record, insertByName, insertByAlias string) (int, error) {
 	ctx, cancel := dbCtx()
 	defer cancel()
 
+	misses := 0
 	err := pool.BeginFunc(ctx, func(tx pgx.Tx) error {
 		b := &pgx.Batch{}
 		inserts := 0
 
 		for _, val := range data {
-			b.Queue(insertStatement, SPARKPLUG_GROUP_ID,
-				node_id, device_id,
-				string(val.Name[:]), val.Ts/1000, val.Val)
+			name := recordName(val)
+			if aliasStr, ok := strings.CutPrefix(name, aliasRecordPrefix); ok {
+				alias, perr := strconv.ParseUint(aliasStr, 10, 64)
+				if perr != nil {
+					log.Warn().Str("record", name).Msg("Skipping malformed alias WAL record")
+					continue
+				}
+				b.Queue(insertByAlias, SPARKPLUG_GROUP_ID,
+					node_id, device_id,
+					alias, val.Ts/1000, val.Val)
+			} else {
+				b.Queue(insertByName, SPARKPLUG_GROUP_ID,
+					node_id, device_id,
+					name, val.Ts/1000, val.Val)
+			}
 			inserts++
 		}
 
 		batchResults := tx.SendBatch(ctx, b)
 		for i := 0; i < inserts; i++ {
-			_, err := batchResults.Exec()
+			tag, err := batchResults.Exec()
 			if err != nil {
 				batchResults.Close()
 				return err
+			}
+			// 0 rows: lookup missed (transient — retried) or the
+			// row already existed (conflict — replay dedups).
+			if tag.RowsAffected() == 0 {
+				misses++
 			}
 		}
 
@@ -238,15 +358,9 @@ ON CONFLICT (metric_id, time) DO NOTHING`
 			log.Warn().Err(err).Msg("Recovery commit error")
 			return err
 		}
-		log.Info().
-			Str("node_id", node_id).
-			Str("device_id", device_id).
-			Int("count", inserts).
-			Msg("Recovery complete")
-
 		return nil
 	})
-	return err
+	return misses, err
 }
 
 func recoveryWorker() {


### PR DESCRIPTION
## Summary

Three bugs in `sparkplug-sql` that cause unbounded disk growth on installations where one or more nodes cannot fulfill a requested sequence number:

- **`trackVersions`: unbounded DESYNCED→RECOVERING loop** — each cycle sends an NCMD retry-request, which triggers NDEATH/NBIRTH on the edge, wiping the alias map in the DB. DDATA inserts then fail the `metric_alias` lookup and write new `.recovery` files. Without a ceiling this repeats every 5 minutes forever. Adds `MAX_RECOVERY_ATTEMPTS` env var (default 5, ~25 min) after which the node is marked GOOD and retry-requests stop. Counter only resets on full recovery (NDATA UUID match → STATE_GOOD), not on partial hdata, so a node that returns only heartbeat traffic cannot reset the clock indefinitely.

- **`invalidateAliases`: shared context across retry loop** — a single 60s context was created before the `for` loop. After expiry every subsequent attempt failed immediately with `context deadline exceeded` without touching the pool, producing sustained error spam. Moves `ctx/cancel` inside the loop so each attempt gets a fresh timeout.

- **`recoverFile`: null-metric-id failures retried indefinitely** — only `"not permitted on chunk"` caused a segment to be marked `.tooold`. `"null value in column metric_id"` / `"violates not-null constraint"` (metric missing from metadata, or name truncated in the 36-byte WAL record) would never succeed on retry but kept the file alive for 5-second retries forever. Adds these error strings to the `.tooold` condition.

## Test plan

- [ ] Deploy to an installation with nodes stuck in retry-request loop; confirm `"Max recovery attempts reached"` logs after 5 cycles and retry-requests stop
- [ ] Confirm `"Marking unrecoverable segment as tooold"` fires for `.recovery` files whose metric is not in metadata
- [ ] Confirm disk usage stabilises after stuck nodes exhaust retry limit
- [ ] Confirm normally-recovering nodes (NDATA UUID match) still transition to STATE_GOOD and reset the counter correctly